### PR TITLE
 Updates for linkedator-api-0.0.3 (linkedator-0.0.4).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,16 +31,6 @@
 			<version>2.23.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-beans</artifactId>
-			<version>4.3.0.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-			<version>4.3.0.RELEASE</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>br.ufsc.inf.lapesd</groupId>
 	<artifactId>linkedator-jersey</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
+	<version>0.0.4-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>br.ufsc.inf.lapesd</groupId>
 			<artifactId>linkedator</artifactId>
-			<version>0.0.3-SNAPSHOT</version>
+			<version>0.0.4-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- LinkedatorApi loads the configuration only once, if requested through
loadConfig(). The configuration can be edited programatically.
- LinkedatorApi interface was changed to receive the entity MediaType
and pass it along
- LinkedadorWriterInterceptor stamps its time with a header.
- LinkedadorWriterInterceptor can be used either as provider class or
as a singleton (for configuration of its own private LinkedatorApi)
in Application subclasses.

Version bumped from 0.0.3 to 0.0.4